### PR TITLE
Get real extension ID

### DIFF
--- a/extension/injectors/editor.js
+++ b/extension/injectors/editor.js
@@ -1,13 +1,16 @@
-console.log('injecting editor.js')
+console.log("injecting editor.js");
 
 // alert(chrome.runtime.id)
-let scriptElem = document.createElement('script')
-let srcThign = chrome.runtime.getURL("/scripts/editor.js")
-scriptElem.src = srcThign
+let scriptElem = document.createElement("script");
+scriptElem.dataset.exId = chrome.runtime.id
+scriptElem.classList.add("blocklive-ext")
+let srcThign = chrome.runtime.getURL("/scripts/editor.js");
+
+scriptElem.src = srcThign;
 // document.body.append(scriptElem)
 
-if(!!document.head) {
-    document.head.appendChild(scriptElem)
+if (!!document.head) {
+  document.head.appendChild(scriptElem);
 } else {
-    document.documentElement.appendChild(scriptElem)
+  document.documentElement.appendChild(scriptElem);
 }

--- a/extension/injectors/mystuff.js
+++ b/extension/injectors/mystuff.js
@@ -2,6 +2,8 @@ console.log('injecting mystuff.js')
 
 // alert(chrome.runtime.id)
 let scriptElem = document.createElement('script')
+scriptElem.dataset.exId = chrome.runtime.id
+scriptElem.classList.add("blocklive-ext")
 let srcThign = chrome.runtime.getURL("/scripts/mystuff.js")
 scriptElem.src = srcThign
 // document.body.append(scriptElem)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,10 +15,6 @@
             "matches":["https://scratch.mit.edu/mystuff*"],
             "css":[],
             "js":["injectors/mystuff.js"]
-        },{
-            "matches":["https://turbowarp.org/editor"],
-            "css":[],
-            "js":["injectors/turbowarp_editor.js"]
         }
     ],
     "background": {

--- a/extension/scripts/editor.js
+++ b/extension/scripts/editor.js
@@ -1,7 +1,7 @@
 console.log('CollabLive Editor Inject Running...')
 
-// var exId = 'gelkmljpoacdjkjkcfekkmgkpnmeomlk' // real
-var exId = 'pbhmkinipohcnagebjpbolglhfebplkm' // test
+// get exId
+const exId = document.querySelector(".blocklive-ext").dataset.exId
 
 //////////// TRAP UTILS ///////////
 

--- a/extension/scripts/mystuff.js
+++ b/extension/scripts/mystuff.js
@@ -1,7 +1,7 @@
 console.log('mystuff inject started')
 
-// var exId = 'gelkmljpoacdjkjkcfekkmgkpnmeomlk' // real
-var exId = 'pbhmkinipohcnagebjpbolglhfebplkm' // test
+// get exId
+const exId = document.querySelector(".blocklive-ext").dataset.exId
 
 ////////// INJECT UTILS //////////
 


### PR DESCRIPTION
Before, the extension ID was set in the `/scripts/editor.js`. That made it difficult to use local versions of Blocklive, as well as could be dangerous to mistakes.

Now, the `/injectors/editor.js` file sets the `data-exId` to the `chrome.runtime.id` so that the `/editor/editor.js` file can easily get the accurate extension ID no matter what.

I also just randomly formatted the code :/