### PR TITLE
Better method for getting Scratch project ID

### DIFF
--- a/extension/scripts/editor.js
+++ b/extension/scripts/editor.js
@@ -106,12 +106,23 @@ var blockliveServer
 
 let blId = ''
 blVersion = 0
-scratchId = location.pathname.split('/')[2] //TODO: use better method?
-// scratchId = '644532638'
+
+// get vm
+function scratchGUI() {
+    return window.vm ||
+(() => {
+  const app = document.querySelector("#app");
+  return app[
+    Object.keys(app).find((key) => key.startsWith("__reactContainer"))
+  ].child.stateNode.store.getState().scratchGui;
+})();
+}
+let vm = scratchGUI().vm
+
+scratchId = scratchGUI().projectState.projectId
 let pauseEventHandling = false
 let projectReplaceInitiated = false
 let onceProjectLoaded = []
-let vm
 let readyToRecieveChanges = false
 
 async function startBlocklive(creatingNew) {
@@ -136,14 +147,13 @@ async function onTabLoad() {
     // Get usable scratch id
     // await waitFor(()=>{!isNaN(parseFloat(location.pathname.split('/')[2]))})
     // scratchId = location.pathname.split('/')[2]
-    waitFor(()=>(!isNaN(parseFloat(location.pathname.split('/')[2])))).then(()=>{scratchId = location.pathname.split('/')[2]})
+    waitFor(()=>(!isNaN(parseFloat(scratchGUI().projectState.projectId)))).then(()=>{scratchId = scratchGUI().projectState.projectId})
 
     // trap vm and store
     let reactInst = Object.values(await getObj('div[class^="stage-wrapper_stage-wrapper_"]')).find((x) => x.child)
-    vm = reactInst.child.child.child.stateNode.props.vm;
     store = reactInst.child.child.child.stateNode.context.store
     addButtonInjectors()
-    blId = isNaN(parseFloat(location.pathname.split('/')[2])) ? '' : await getBlocklyId(scratchId);
+    blId = isNaN(parseFloat(scratchGUI().projectState.projectId)) ? '' : await getBlocklyId(scratchId);
     if(!blId) {
         chrome.runtime.sendMessage(exId,{meta:'callback'},(request) => { if(request.meta == 'initBlocklive') { 
             blId = request.blId; 
@@ -1908,8 +1918,8 @@ let blActivateClick = async ()=>{
     // save project in scratch
     store.dispatch({type: "scratch-gui/project-state/START_MANUAL_UPDATING"})
 
-    await waitFor(()=>(!isNaN(parseFloat(location.pathname.split('/')[2]))))
-    scratchId = location.pathname.split('/')[2]
+    await waitFor(()=>(!isNaN(parseFloat(scratchGUI().projectState.projectId))))
+    scratchId = scratchGUI().projectState.projectId
 
     let json = vm.toJSON()
 


### PR DESCRIPTION
Currently, Blocklive uses the website location to get the project ID. This isn't a great method for getting the project ID, so now this uses the Scratch GUI to get the project ID.

This uses `scratchGUI().projectState.projectId`.